### PR TITLE
Spearbit-1: fix single-block replays

### DIFF
--- a/foundry-contracts/src/RouterRebates.sol
+++ b/foundry-contracts/src/RouterRebates.sol
@@ -59,7 +59,7 @@ contract RouterRebates is EIP712, Owned {
     ) external {
         // startBlockNumber must be less than endBlockNumber
         if (blockRange.startBlockNumber > blockRange.endBlockNumber) revert InvalidBlockNumber();
-        if (blockRange.startBlockNumber < lastBlockClaimed[chainId][beneficiary]) revert InvalidBlockNumber();
+        if (blockRange.startBlockNumber <= lastBlockClaimed[chainId][beneficiary]) revert InvalidBlockNumber();
 
         // TODO: explore calldata of keccak256/encodePacked for optimization
         bytes32 digest = ClaimableHash.hashClaimable(
@@ -68,7 +68,7 @@ contract RouterRebates is EIP712, Owned {
         signature.verify(_hashTypedDataV4(digest), signer);
 
         // consume the block number to prevent replaying claims
-        lastBlockClaimed[chainId][beneficiary] = blockRange.endBlockNumber - 1;
+        lastBlockClaimed[chainId][beneficiary] = blockRange.endBlockNumber;
 
         // send amount to recipient
         CurrencyLibrary.ADDRESS_ZERO.transfer(recipient, amount);


### PR DESCRIPTION
Spearbit-1: 

> only prevents claims where the startBlockNumber is less than the last claimed block. This means a claim with startBlockNumber equal to the previous claim's endBlockNumber will pass validation, allowing the last block to be claimed multiple times.

