### PR TITLE
Spearbit-3: Duplicate Hashes

### DIFF
--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -26,7 +26,7 @@ app.get("/sign", async (c) => {
   }
 
   const publicClient = getClient(Number(chainId));
-  let txnHashList = txnHashes.split(",") as `0x${string}`[];
+  const txnHashList = txnHashes.split(",") as `0x${string}`[];
 
   const result = await batch(publicClient, txnHashList);
 

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -26,7 +26,10 @@ app.get("/sign", async (c) => {
   }
 
   const publicClient = getClient(Number(chainId));
-  const txnHashList = txnHashes.split(",") as `0x${string}`[];
+  let txnHashList = txnHashes.split(",") as `0x${string}`[];
+
+  // deduplicate txn hashes
+  txnHashList = [...new Set(txnHashList)];
 
   const result = await batch(publicClient, txnHashList);
 

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -28,9 +28,6 @@ app.get("/sign", async (c) => {
   const publicClient = getClient(Number(chainId));
   let txnHashList = txnHashes.split(",") as `0x${string}`[];
 
-  // deduplicate txn hashes
-  txnHashList = [...new Set(txnHashList)];
-
   const result = await batch(publicClient, txnHashList);
 
   return c.json(result);

--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -16,7 +16,7 @@ export async function batch(
     await getRebatePerEvent();
 
   // deduplicate the txnHashes
-  const uniqueTxnHashes = Array.from(new Set(txnHashes));
+  const uniqueTxnHashes = Array.from(new Set(txnHashes.map((hash) => hash.toLowerCase() as `0x${string}`)));
 
   const result = await Promise.all(
     uniqueTxnHashes.map((txnHash) =>

--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -12,8 +12,11 @@ export async function batch(
   startBlockNumber: string;
   endBlockNumber: string;
 }> {
+  // deduplicate the txnHashes
+  const uniqueTxnHashes = Array.from(new Set(txnHashes));
+
   const result = await Promise.all(
-    txnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
+    uniqueTxnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
   );
 
   const amount = result.reduce(


### PR DESCRIPTION
Spearbit 3
> The aggregator /sign endpoint allows providing a comma‐separated list of txnHashes. If the same transaction hash appears multiple times, the aggregator treats each entry as a distinct transaction

> Consequently, the amount returned is effectively tripled. This is demonstrated by the example below using 2× vs. 4× duplicates, where the resulting signature’s amount scales accordingly

* Added deduplication before computing rebate