### PR TITLE
Spearbit-12: Index only hooked pools

### DIFF
--- a/signer/src/index.ts
+++ b/signer/src/index.ts
@@ -1,14 +1,17 @@
 import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
+import { zeroAddress } from "viem";
 
 ponder.on("PoolManager:Initialize", async ({ event, context }) => {
-  await context.db.insert(schema.pool).values({
-    poolId: event.args.id,
-    currency0: event.args.currency0,
-    currency1: event.args.currency1,
-    fee: event.args.fee,
-    tickSpacing: event.args.tickSpacing,
-    hooks: event.args.hooks,
-    chainId: context.network.chainId,
-  });
+  if (event.args.hooks !== zeroAddress) {
+    await context.db.insert(schema.pool).values({
+      poolId: event.args.id,
+      currency0: event.args.currency0,
+      currency1: event.args.currency1,
+      fee: event.args.fee,
+      tickSpacing: event.args.tickSpacing,
+      hooks: event.args.hooks,
+      chainId: context.network.chainId,
+    });
+  }
 });


### PR DESCRIPTION
Spearbit 12

> Every time a new Uniswap v4 pool is created on any supported chain, it’s inserted into schema.pool. Because the aggregator is configured for multiple networks, if they see heavy pool creation activity, the database can balloon indefinitely. With no built‐in constraints or cleanup, the aggregator risks running out of disk space crashing or seeing very slow queries.

Updated ponder indexing to only index pool keys with `key.hooks != address(0)`