### PR TITLE
Spearbit-10: designate beneficary address as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ To prevent signature replays and/or duplicate claiming, rebate claims operate on
    txnHashList = ["0xABC", "0xDEF"]
    ```
 
-2. Provide the chainId and transaction list to the API
+2. Provide the chainId, transaction list, and the beneficiary address (swap router) to the API
 
    ```bash
    curl -G 'https://router-rebates-testnet.up.railway.app/sign' \
      --data-urlencode 'chainId=1' \
      --data-urlencode 'txnHashes=0xABC,0xDEF'
+     --data-urlencode 'beneficiary=0xA1B2C3
    ```
 
 3. Example response:

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -25,10 +25,17 @@ app.get("/sign", async (c) => {
     );
   }
 
+  const beneficiary = c.req.query("beneficiary");
+  if (beneficiary === undefined) {
+    return c.text(
+      "provide beneficiary as query parameter, the address of the contract (in the Swap event): &beneficiary=0x123"
+    );
+  }
+
   const publicClient = getClient(Number(chainId));
   const txnHashList = txnHashes.split(",") as `0x${string}`[];
 
-  const result = await batch(publicClient, txnHashList);
+  const result = await batch(publicClient, txnHashList, beneficiary);
 
   return c.json(result);
 });

--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -4,7 +4,8 @@ import { getRebateClaimer, sign } from "./signer";
 
 export async function batch(
   publicClient: PublicClient,
-  txnHashes: `0x${string}`[]
+  txnHashes: `0x${string}`[],
+  beneficiary: Address
 ): Promise<{
   claimer: Address;
   signature: `0x${string}`;
@@ -12,23 +13,25 @@ export async function batch(
   startBlockNumber: string;
   endBlockNumber: string;
 }> {
-  const result = await Promise.all(
+  let result = await Promise.all(
     txnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
   );
+
+  // filter out any rebates that do not correlate to the beneficiary
+  result = result.filter((data) => data.beneficiary === beneficiary);
 
   const amount = result.reduce(
     (total: bigint, data) => total + data.gasToRebate,
     0n
   );
-  const beneficiary: `0x${string}` = result[0].beneficiary;
   const claimer = await getRebateClaimer(publicClient, beneficiary);
   const startBlockNumber = result.reduce(
     (min: bigint, data) => (data.blockNumber < min ? data.blockNumber : min),
-    result[0].blockNumber
+    BigInt(Number.MAX_SAFE_INTEGER)
   );
   const endBlockNumber = result.reduce(
     (max: bigint, data) => (data.blockNumber > max ? data.blockNumber : max),
-    result[0].blockNumber
+    0n
   );
 
   const signature = await sign(

--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -14,11 +14,10 @@ export async function batch(
   endBlockNumber: string;
 }> {
   let result = await Promise.all(
-    txnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
+    txnHashes.map((txnHash) =>
+      calculateRebate(publicClient, txnHash, beneficiary)
+    )
   );
-
-  // filter out any rebates that do not correlate to the beneficiary
-  result = result.filter((data) => data.beneficiary === beneficiary);
 
   const amount = result.reduce(
     (total: bigint, data) => total + data.gasToRebate,


### PR DESCRIPTION
Callers of `/sign` must provide the beneficiary they will claim against. This better supports 4337 bundled transactions, and prevents malicious multi-beneficiary inputs