### PR TITLE
Spearbit-27: note duplicate pool records

### DIFF
--- a/signer/src/api/util/rebate.ts
+++ b/signer/src/api/util/rebate.ts
@@ -62,7 +62,10 @@ export async function calculateRebate(
   // iterate each swap event, calculating the rebate for the sender (swap router)
   const rebates = await Promise.all(
     swapEvents.map(async (swapEvent) => {
-      const { id } = swapEvent.args;
+      const { id } = swapEvent.args; // poolId from the swap event
+
+      // NOTE: the database is indexing across multiple chains, so it may fetch duplicates (same poolId, hook address, currencies, etc)
+      // the database is used to associate a poolId with a hook address, so duplicates are deemed safe
       const result = await dbClient
         .select({ hooks: schema.pool.hooks })
         .from(schema.pool)


### PR DESCRIPTION
> The database can potentially contain duplicate pool ids if two pools with the same token addresses and hooks are deployed on different chains. This could lead to the wrong pool being fetched from the database. Fetching the pool from the wrong chain should not have any impact on the current functionality as the pools would be identical, however in the event this code needs to be extended in a manner that something needs to be stored in the database, it would end up being stored in the wrong item.

Duplicates are safe, but added an inline comment in case the database records would be used differently