### PR TITLE
Spearbit-17: early-return on no rebates

### DIFF
--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -1,4 +1,4 @@
-import type { Address, PublicClient } from "viem";
+import { zeroAddress, type Address, type PublicClient } from "viem";
 import { calculateRebate } from "./rebate";
 import { getRebateClaimer, sign } from "./signer";
 
@@ -20,6 +20,19 @@ export async function batch(
     (total: bigint, data) => total + data.gasToRebate,
     0n
   );
+
+  // no rebates were found from the transaction hashes provided
+  // early-return to avoid `getRebateClaimer` call and signature generation
+  if (amount === 0n) {
+    return {
+      claimer: zeroAddress,
+      signature: "0x0",
+      amount: "0",
+      startBlockNumber: "0",
+      endBlockNumber: "0",
+    };
+  }
+
   const beneficiary: `0x${string}` = result[0].beneficiary;
   const claimer = await getRebateClaimer(publicClient, beneficiary);
   const startBlockNumber = result.reduce(


### PR DESCRIPTION
> The function can return empty result if no swap events is detected.
> const result = await Promise.all(
>    txnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
>  );

> If beneficiary return address(0),
> const claimer = await getRebateClaimer(publicClient, beneficiary);
> quering claimer in address(0) will raise error.

---

Early-return when no rebates are available