### PR TITLE
Spearbit-18: reduce RPC calls for rebate look up

### DIFF
--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -1,5 +1,5 @@
 import type { Address, PublicClient } from "viem";
-import { calculateRebate } from "./rebate";
+import { calculateRebate, getRebatePerEvent } from "./rebate";
 import { getRebateClaimer, sign } from "./signer";
 
 export async function batch(
@@ -12,8 +12,18 @@ export async function batch(
   startBlockNumber: string;
   endBlockNumber: string;
 }> {
+  const { rebatePerSwap, rebatePerHook, rebateFixed } =
+    await getRebatePerEvent();
   const result = await Promise.all(
-    txnHashes.map((txnHash) => calculateRebate(publicClient, txnHash))
+    txnHashes.map((txnHash) =>
+      calculateRebate(
+        publicClient,
+        txnHash,
+        rebatePerSwap,
+        rebatePerHook,
+        rebateFixed
+      )
+    )
   );
 
   const amount = result.reduce(

--- a/signer/src/api/util/rebate.ts
+++ b/signer/src/api/util/rebate.ts
@@ -22,7 +22,10 @@ export function getUNIFromETHAmount(ethAmount: bigint): bigint {
 /// @dev rebates are only calculated for the first swap router
 export async function calculateRebate(
   client: PublicClient,
-  txnHash: `0x${string}`
+  txnHash: `0x${string}`,
+  rebatePerSwap: bigint,
+  rebatePerHook: bigint,
+  rebateFixed: bigint
 ): Promise<{
   beneficiary: Address;
   gasToRebate: bigint;
@@ -30,8 +33,6 @@ export async function calculateRebate(
   blockNumber: bigint;
 }> {
   const txnReceipt = await client.getTransactionReceipt({ hash: txnHash });
-  const { rebatePerSwap, rebatePerHook, rebateFixed } =
-    await getRebatePerEvent();
 
   // Use baseFee and do not use priorityFee, otherwise miners will set a high priority fee (paid back to themselves)
   // and be able to wash trade
@@ -91,7 +92,7 @@ export async function calculateRebate(
   };
 }
 
-async function getRebatePerEvent(): Promise<{
+export async function getRebatePerEvent(): Promise<{
   rebatePerSwap: bigint;
   rebatePerHook: bigint;
   rebateFixed: bigint;


### PR DESCRIPTION
> If the txnHashes array contains 1000 tx hashes,
> calculateRebate runs 1000 times,
> For each calculateRebate, await getRebatePerEvent() runs

Reduce RPC calls, by calling `getRebatePerEvent` once per `/sign` call