### PR TITLE
Spearbit-4: Add rate-limit

### DIFF
--- a/signer/package-lock.json
+++ b/signer/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ponder/client": "^0.9.7",
         "hono": "^4.5.0",
+        "hono-rate-limiter": "^0.4.2",
         "ponder": "^0.9.7",
         "viem": "^2.21.3"
       },
@@ -5904,6 +5905,14 @@
       "integrity": "sha512-hV97aIR4WYbG30k234sD9B3VNr1ZWdQRmrVF76LKFlmI7O9Yo70mG9+mFwyQ6Sjrz4wH71GfnBxv6CPjcx3QNw==",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hono-rate-limiter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/hono-rate-limiter/-/hono-rate-limiter-0.4.2.tgz",
+      "integrity": "sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw==",
+      "peerDependencies": {
+        "hono": "^4.1.1"
       }
     },
     "node_modules/html-escaper": {

--- a/signer/package.json
+++ b/signer/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ponder/client": "^0.9.7",
     "hono": "^4.5.0",
+    "hono-rate-limiter": "^0.4.2",
     "ponder": "^0.9.7",
     "viem": "^2.21.3"
   },

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { graphql } from "ponder";
 import { batch } from "./util/main";
 import { getClient } from "./util/chain";
+import { rateLimiter } from "hono-rate-limiter";
 
 const app = new Hono();
 
@@ -12,6 +13,17 @@ const app = new Hono();
 
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
+
+// rate limit the sign endpoint
+app.use(
+  "/sign",
+  rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 50,
+    keyGenerator: (c) => c.req.query("beneficiary") ?? "defaultKey",
+    message: "Too many requests exceeded per minute"
+  })
+);
 
 app.get("/sign", async (c) => {
   const chainId = c.req.query("chainId");


### PR DESCRIPTION
> Currently, the aggregator /sign endpoint can be queried freely without authentication or throttling. Each incoming request triggers RPC calls to Alchemy (or similar providers) to fetch transaction receipts, blocks, logs, etc. If an attacker sends enough requests in quick succession, they can consume the aggregator’s entire Alchemy rate limit or subscription credits. Once those are gone, legitimate queries fail and the service effectively experiences a denial of service.

Added a rate limit of 100 requests per minute per beneficiary address