### PR TITLE
Spearbit-5: do not surface errors through the endpoint

### DIFF
--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -25,12 +25,17 @@ app.get("/sign", async (c) => {
     );
   }
 
-  const publicClient = getClient(Number(chainId));
-  const txnHashList = txnHashes.split(",") as `0x${string}`[];
+  try {
+    const publicClient = getClient(Number(chainId));
+    const txnHashList = txnHashes.split(",") as `0x${string}`[];
 
-  const result = await batch(publicClient, txnHashList);
+    const result = await batch(publicClient, txnHashList);
 
-  return c.json(result);
+    return c.json(result);
+  } catch (e) {
+    console.error(e);
+    return c.text("Something went wrong");
+  }
 });
 
 export default app;


### PR DESCRIPTION
> When the aggregator is flooded with calls to the /sign endpoint, it exhausts Alchemy’s rate limit or compute units. Alchemy then responds with a 429 status including a body that references a URL like:

https://eth-sepolia.g.alchemy.com/v2/API_KEY

This discloses the aggregator’s Alchemy API key in plain text. Attackers can glean this key from the aggregator’s logs or error messages and then use it further draining the subscription or forging data requests. Additionally, repeated 429 errors cause partial unavailability for legitimate requests.

* Catch errors and only log them internally