### PR TITLE
Separate owner and signer

### DIFF
--- a/foundry-contracts/script/Anvil.s.sol
+++ b/foundry-contracts/script/Anvil.s.sol
@@ -52,7 +52,11 @@ contract AnvilScript is Script {
         vm.stopBroadcast();
 
         vm.startBroadcast();
-        rebates = new RouterRebates("FOUNDATION", address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266));
+        rebates = new RouterRebates(
+            "FOUNDATION",
+            address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266),
+            address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)
+        );
         rewardToken.mint(msg.sender, 1_000_000e18);
         rewardToken.approve(address(rebates), type(uint256).max);
         vm.stopBroadcast();

--- a/foundry-contracts/script/DeployRouterRebates.s.sol
+++ b/foundry-contracts/script/DeployRouterRebates.s.sol
@@ -27,7 +27,11 @@ contract DeployRouterRebatesScript is Script {
 
     function run() public {
         vm.broadcast();
-        RouterRebates rebates = new RouterRebates("FOUNDATION", address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8));
+        RouterRebates rebates = new RouterRebates(
+            "FOUNDATION",
+            address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8),
+            address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8)
+        );
 
         vm.broadcast();
         (bool success,) = address(rebates).call{value: 0.02 ether}("");

--- a/foundry-contracts/src/RouterRebates.sol
+++ b/foundry-contracts/src/RouterRebates.sol
@@ -46,8 +46,8 @@ contract RouterRebates is ReentrancyGuard, EIP712, Owned {
     uint256 constant MAX_REBATE_PER_HOOK = 80_000;
     uint256 constant MAX_REBATE_FIXED = 120_000;
 
-    constructor(string memory _name, address _owner) EIP712(_name, "1") Owned(_owner) {
-        signer = _owner;
+    constructor(string memory _name, address _owner, address _signer) EIP712(_name, "1") Owned(_owner) {
+        signer = _signer;
     }
 
     function claimWithSignature(

--- a/foundry-contracts/test/RouterRebates.claimWithSignature.t.sol
+++ b/foundry-contracts/test/RouterRebates.claimWithSignature.t.sol
@@ -27,12 +27,10 @@ contract RouterRebatesTest is Test {
     error InvalidAmount();
 
     function setUp() public {
-        rebates = new RouterRebates("REBATES", address(this));
-
         (alice, alicePK) = makeAddrAndKey("ALICE");
         (bob, bobPK) = makeAddrAndKey("BOB");
 
-        rebates.setSigner(alice);
+        rebates = new RouterRebates("REBATES", address(this), alice);
 
         // deposit and fund the campaign
         vm.deal(address(rebates), 10 ether);


### PR DESCRIPTION
For the sake of opsec, lets separate the owner and signer which are independently designated at deployment