### PR TITLE
Spearbit-30: incorrect min block number

### DIFF
--- a/signer/src/api/util/main.ts
+++ b/signer/src/api/util/main.ts
@@ -40,7 +40,9 @@ export async function batch(
   );
 
   // filter out any invalid transactions, where beneficiary is zero address
-  result = result.filter((data) => data.beneficiary !== zeroAddress);
+  result = result.filter(
+    (data) => data.beneficiary !== zeroAddress && data.gasToRebate > 0n
+  );
 
   const amount = result.reduce(
     (total: bigint, data) => total + data.gasToRebate,


### PR DESCRIPTION
> When the batch function processes transactions that do not produce a rebate (gasToRebate = 0n), it still includes them in the reducer used to determine the minimum and maximum block numbers. Since calculateRebate sets blockNumber = 0n for zero-rebate transactions, the reducer will yield startBlockNumber = 0, even if legitimate rebate-bearing transactions occur at a much higher block. This is counterintuitive, as the “real” earliest relevant block should reflect only those transactions that actually triggered a swap event.

The PR https://github.com/uniswapfoundation/router-rebates/pull/46 introduced a bug when calculating the startBlockNumber. This was fixed/addressed in https://github.com/uniswapfoundation/router-rebates/pull/45 but for the sake of clarity, I made it explicit such that results with a gasToRebate=0n are additionally excluded