### PR TITLE
Spearbit-7: Rate limit by IP

### DIFF
--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -7,7 +7,6 @@ import { getClient } from "./util/chain";
 import { rateLimiter } from "hono-rate-limiter";
 import { getConnInfo as nodeConnInfo } from "@hono/node-server/conninfo";
 import { getConnInfo as vercelConnInfo } from "hono/vercel";
-import { getConnInfo as lambdaConnInfo } from 'hono/lambda-edge'
 import { getConnInfo as cloudflareConnInfo } from 'hono/cloudflare-workers'
 
 const app = new Hono();
@@ -21,12 +20,10 @@ app.use("/graphql", graphql({ db, schema }));
 app.use("/test-ip", async (c) => {
   const nodeInfo = nodeConnInfo(c);
   const vercelInfo = vercelConnInfo(c);
-  const lambdaInfo = lambdaConnInfo(c);
   const cloudflareInfo = cloudflareConnInfo(c);
   return c.json({
     node: nodeInfo.remote.address,
     vercel: vercelInfo.remote.address,
-    lambda: lambdaInfo.remote.address,
     cloudflare: cloudflareInfo.remote.address,
   });
 })

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -15,7 +15,7 @@ const app = new Hono();
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
 
-// rate limit the sign endpoint
+// rate limit the test endpoint
 app.use(
   "/test-ip",
   rateLimiter({

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -8,7 +8,6 @@ import { rateLimiter } from "hono-rate-limiter";
 import { getConnInfo as nodeConnInfo } from "@hono/node-server/conninfo";
 import { getConnInfo as vercelConnInfo } from "hono/vercel";
 import { getConnInfo as lambdaConnInfo } from 'hono/lambda-edge'
-import { getConnInfo as denoConnInfo } from 'hono/deno'
 import { getConnInfo as cloudflareConnInfo } from 'hono/cloudflare-workers'
 
 const app = new Hono();
@@ -23,13 +22,11 @@ app.use("/test-ip", async (c) => {
   const nodeInfo = nodeConnInfo(c);
   const vercelInfo = vercelConnInfo(c);
   const lambdaInfo = lambdaConnInfo(c);
-  const denoInfo = denoConnInfo(c);
   const cloudflareInfo = cloudflareConnInfo(c);
   return c.json({
     node: nodeInfo.remote.address,
     vercel: vercelInfo.remote.address,
     lambda: lambdaInfo.remote.address,
-    deno: denoInfo.remote.address,
     cloudflare: cloudflareInfo.remote.address,
   });
 })

--- a/signer/src/api/index.ts
+++ b/signer/src/api/index.ts
@@ -5,6 +5,7 @@ import { graphql } from "ponder";
 import { batch } from "./util/main";
 import { getClient } from "./util/chain";
 import { rateLimiter } from "hono-rate-limiter";
+import { getConnInfo } from "@hono/node-server/conninfo";
 
 const app = new Hono();
 
@@ -13,6 +14,11 @@ const app = new Hono();
 
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
+
+app.use("/test_ip", async (c) => {
+  const info = getConnInfo(c);
+  return c.text(info.remote.address ?? "unknown remote address");
+})
 
 // rate limit the sign endpoint
 app.use(


### PR DESCRIPTION
While rate-limiting by IP can be circumvented with VPNs, proxies, and a network of bots, it's a better approach than user-provided beneficiary addresses

IP-based rate-limiting prevents DOSing other participants